### PR TITLE
cnid_metad.c: Making setlimits errors non-terminal as a workaround for cnid_metad shutdowns on macOS 10.14 Mojave

### DIFF
--- a/etc/cnid_dbd/cnid_metad.c
+++ b/etc/cnid_dbd/cnid_metad.c
@@ -425,7 +425,7 @@ static int setlimits(void)
 
     if (getrlimit(RLIMIT_NOFILE, &rlim) != 0) {
         LOG(log_error, logtype_afpd, "setlimits: %s", strerror(errno));
-        exit(1);
+        /* exit(1); */
     }
     if (rlim.rlim_cur != RLIM_INFINITY && rlim.rlim_cur < 65535) {
         rlim.rlim_cur = 65535;
@@ -433,7 +433,7 @@ static int setlimits(void)
             rlim.rlim_max = 65535;
         if (setrlimit(RLIMIT_NOFILE, &rlim) != 0) {
             LOG(log_error, logtype_afpd, "setlimits: %s", strerror(errno));
-            exit(1);
+            /* exit(1); */
         }
     }
     return 0;

--- a/netatalk-init
+++ b/netatalk-init
@@ -1,8 +1,14 @@
-#Startup daemon for Netatalk on macOS
+# Startup daemon for Netatalk on macOS
 
 #!/bin/zsh
 
 set -e
+
+# root check
+if [ "$(id -u)" != "0" ]; then
+   printf "Error: The startup daemon for Netatalk needs to be executed with sudo privileges.\n" 1>&2
+   exit 1
+fi
 
 PREFIX=/usr/local
 


### PR DESCRIPTION
This will change the status of setlimits errors to "non-terminal", i.e. these will no longer terminate the cnid_metad daemon on macOS 10.14 Mojave right after launch, if occurring.