### PR TITLE
Added root check to startup daemon, termination if no root privileges are detected

### DIFF
--- a/netatalk-init
+++ b/netatalk-init
@@ -1,8 +1,14 @@
-#Startup daemon for Netatalk on macOS
+# Startup daemon for Netatalk on macOS
 
 #!/bin/zsh
 
 set -e
+
+# root check
+if [ "$(id -u)" != "0" ]; then
+   printf "Error: The startup daemon for Netatalk needs to be executed with sudo privileges.\n" 1>&2
+   exit 1
+fi
 
 PREFIX=/usr/local
 


### PR DESCRIPTION
Netatalk3 on macOS currently needs to be run with root privileges (in theory, its binaries can be executed within a normal user's context, but they won't provide any useful functionality). To reflect that, this four-liner checks if the startup daemon is executed with root privileges and will terminate the script if no root privileges are detected.