### PR TITLE
Fix html documentation undef variable

### DIFF
--- a/doc/manpages/man1/afpstats.1.xml
+++ b/doc/manpages/man1/afpstats.1.xml
@@ -36,7 +36,7 @@
     "<command>afpd -V</command>".</para>
 
     <para>"<option>afpstats = yes</option>" must be set in
-    <filename>@pkgconfdir@/afp.conf</filename>.</para>
+    <filename>@prefix@/etc/afp.conf</filename>.</para>
 
   </refsect1>
 

--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -415,7 +415,7 @@
                 <listitem>
                   <para>allows Random Number and Two-Way Random Number
                   Exchange for authentication (requires a separate file
-                  containing the passwords, either @pkgconfdir@/afppasswd file or
+                  containing the passwords, either @prefix@/etc/afppasswd file or
                   the one specified via "<option>passwd file</option>"). See
                   <citerefentry>
                       <refentrytitle>afppasswd</refentrytitle>
@@ -460,7 +460,7 @@
 
           <listitem>
             <para>Sets the default path for UAMs for this server (default is
-            @libdir@/netatalk).</para>
+            @prefix@/lib/netatalk).</para>
           </listitem>
         </varlistentry>
       </variablelist>
@@ -541,7 +541,7 @@
 
           <listitem>
             <para>Sets the path to the Randnum UAM passwd file for this server
-            (default is @pkgconfdir@/afppasswd).</para>
+            (default is @prefix@/etc/afppasswd).</para>
           </listitem>
         </varlistentry>
 
@@ -948,7 +948,7 @@
 
           <listitem>
             <para>Sets the path to the file which defines file extension
-            type/creator mappings. (default is @pkgconfdir@/extmap.conf).</para>
+            type/creator mappings. (default is @prefix@/etc/extmap.conf).</para>
           </listitem>
         </varlistentry>
 
@@ -1035,7 +1035,7 @@
             characters. This option is useful for clustered environments, to
             provide fault isolation etc. By default, afpd generate signature
             and saving it to
-            <filename>@localstatedir@/netatalk/afp_signature.conf</filename>
+            <filename>@prefix@/var/netatalk/afp_signature.conf</filename>
             automatically (based on random number). See also
             asip-status.pl(1).</para>
           </listitem>
@@ -1146,7 +1146,7 @@
             <para>Sets the database information to be stored in path. You have
             to specify a writable location, even if the volume is read only.
             The default is
-            <filename>@localstatedir@/netatalk/CNID/$v/</filename>.</para>
+            <filename>@prefix@/var/netatalk/CNID/$v/</filename>.</para>
           </listitem>
         </varlistentry>
 
@@ -2202,7 +2202,7 @@
     not by name. Netatalk needs a way to store these ID's in a persistent way,
     to achieve this several different CNID backends are available. The CNID
     Databases are by default located in the
-    <filename>@localstatedir@/netatalk/CNID/(volumename)/.AppleDB/</filename>
+    <filename>@prefix@/var/netatalk/CNID/(volumename)/.AppleDB/</filename>
     directory.</para>
 
     <variablelist>

--- a/doc/manpages/man5/afp_signature.conf.5.xml
+++ b/doc/manpages/man5/afp_signature.conf.5.xml
@@ -21,7 +21,7 @@
   <refsect1>
     <title>Description</title>
 
-    <para><filename>@localstatedir@/netatalk/afp_signature.conf</filename> is the
+    <para><filename>@prefix@/var/netatalk/afp_signature.conf</filename> is the
     configuration file used by <command>afpd</command> to specify
     server signature automagically. The configuration lines are
     composed like:</para>

--- a/doc/manpages/man5/afp_voluuid.conf.5.xml
+++ b/doc/manpages/man5/afp_voluuid.conf.5.xml
@@ -21,7 +21,7 @@
   <refsect1>
     <title>Description</title>
 
-    <para><filename>@localstatedir@/netatalk/afp_voluuid.conf</filename> is the
+    <para><filename>@prefix@/var/netatalk/afp_voluuid.conf</filename> is the
     configuration file used by <command>afpd</command> to specify
     UUID of Time Machine volume automagically. The configuration
     lines are composed like:</para>

--- a/doc/manpages/man5/extmap.conf.5.xml
+++ b/doc/manpages/man5/extmap.conf.5.xml
@@ -19,7 +19,7 @@
 
   <refsynopsisdiv id="synopsis">
     <cmdsynopsis>
-      <command>@pkgconfdir@/extmap.conf</command>
+      <command>@prefix@/etc/extmap.conf</command>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -27,7 +27,7 @@
     <title>Description</title>
 
     <para>
-    <filename>@pkgconfdir@/extmap.conf</filename> is the
+    <filename>@prefix@/etc/extmap.conf</filename> is the
     configuration file used by <command>afpd</command> to
     specify file name extension mappings.</para>
 

--- a/doc/manpages/man8/afpd.8.xml
+++ b/doc/manpages/man8/afpd.8.xml
@@ -44,7 +44,7 @@
     interface to the Unix file system. It is normally started at boot time
     by <command>netatalk</command>(8).</para>
 
-    <para><filename>@pkgconfdir@/afp.conf</filename> is the configuration file
+    <para><filename>@prefix@/etc/afp.conf</filename> is the configuration file
     used by <command>afpd</command> to determine the behavior and
     configuration of a file server.</para>
 
@@ -92,7 +92,7 @@
 
         <listitem>
           <para>Specifies the configuration file to use. (Defaults to
-          <filename>@pkgconfdir@/afp.conf</filename>.)</para>
+          <filename>@prefix@/etc/afp.conf</filename>.)</para>
         </listitem>
       </varlistentry>
 
@@ -178,7 +178,7 @@
 
     <variablelist>
       <varlistentry>
-        <term><filename>@pkgconfdir@/afp.conf</filename></term>
+        <term><filename>@prefix@/etc/afp.conf</filename></term>
 
         <listitem>
           <para>configuration file used by afpd</para>
@@ -186,7 +186,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@localstatedir@/netatalk/afp_signature.conf</filename></term>
+        <term><filename>@prefix@/var/netatalk/afp_signature.conf</filename></term>
 
         <listitem>
           <para>list of server signature</para>
@@ -194,7 +194,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@localstatedir@/netatalk/afp_voluuid.conf</filename></term>
+        <term><filename>@prefix@/var/netatalk/afp_voluuid.conf</filename></term>
 
         <listitem>
           <para>list of UUID for Time Machine volume</para>
@@ -202,7 +202,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@pkgconfdir@/extmap.conf</filename></term>
+        <term><filename>@prefix@/etc/extmap.conf</filename></term>
 
         <listitem>
           <para>file name extension mapping</para>
@@ -210,7 +210,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@pkgconfdir@/msg/message.pid</filename></term>
+        <term><filename>@prefix@/etc/msg/message.pid</filename></term>
 
         <listitem>
           <para>contains messages to be sent to users.</para>

--- a/doc/manpages/man8/cnid_metad.8.xml
+++ b/doc/manpages/man8/cnid_metad.8.xml
@@ -70,7 +70,7 @@
         <listitem>
           <para>Use <emphasis remap="I">configuration file</emphasis> as the
             configuration file. The default is
-            <emphasis remap="I">@pkgconfdir@/afp.conf</emphasis>.</para>
+            <emphasis remap="I">@prefix@/etc/afp.conf</emphasis>.</para>
         </listitem>
       </varlistentry>
 

--- a/doc/manpages/man8/netatalk.8.xml
+++ b/doc/manpages/man8/netatalk.8.xml
@@ -60,7 +60,7 @@
 
         <listitem>
           <para>Specifies the configuration file to use. (Defaults to
-          <filename>@pkgconfdir@/afp.conf</filename>.)</para>
+          <filename>@prefix@/etc/afp.conf</filename>.)</para>
         </listitem>
       </varlistentry>
 
@@ -95,7 +95,7 @@
 
     <variablelist>
       <varlistentry>
-        <term><filename>@pkgconfdir@/afp.conf</filename></term>
+        <term><filename>@prefix@/etc/afp.conf</filename></term>
 
         <listitem>
           <para>configuration file used by <command>netatalk</command>(8),


### PR DESCRIPTION
To do:

/doc/manpages/man1/uniconv.1.xml
line 56: @DEFAULT_CNID_SCHEME@

/doc/manpages/man5/afp.conf.5.xml
line 923: @DBUS_DAEMON_PATH@
line 1785: @DEFAULT_CNID_SCHEME@
line 1786: @compiled_backends@